### PR TITLE
Improved CLI, templates, output section, first test

### DIFF
--- a/argparse/__init__.py
+++ b/argparse/__init__.py
@@ -65,9 +65,20 @@ for x in __argparse_exports__:
 tools = []
 
 
+def get_arg2cwl_parser():
+    help_text = """
+    argparse2cwl forms CWL tool description from Python tool
+    """
+    arg2cwl_parser = ap.ArgumentParser(prog=sys.argv[0], description=help_text, add_help=False)
+    arg2cwl_parser.add_argument('tools', nargs='*', help='Your tool run commands without arguments')
+    arg2cwl_parser.add_argument('-f', '--file', help='Destination file for writing CWL tool definition')
+    arg2cwl_parser.add_argument('-b', '--basecommand', help='Command that appears in `basecommand` field in CWL tool definition')
+    arg2cwl_parser.add_argument('-ha', '--help_arg2cwl', help='show this help message and exit', action='help')
+    return arg2cwl_parser
+
+
 class ArgumentParser(ap.ArgumentParser):
 
-    # argument_list = []
 
     def __init__(self,
                  prog=None,
@@ -101,27 +112,30 @@ class ArgumentParser(ap.ArgumentParser):
         self.argument_list.append(result)
 
     def parse_args(self, *args, **kwargs):
+        arg2cwl_parser = get_arg2cwl_parser()
         if '--generate_cwl_tool' in sys.argv:
-            # assuming all passed arguments are either commands or argparse2cwl flags
-            command = ''
-            shebang = re.search(r'\./\w*?.py$', sys.argv[0])
-            for arg in sys.argv:
-                if not arg.startswith('--'):
-                    command += '{0} '.format(arg.split('/')[-1])
-                else:
-                    command = command.strip()
-                    kwargs['command'] = command
-                    break
-            if '-f' in sys.argv:
-                kwargs['path'] = sys.argv[sys.argv.index('-f')+1]
-            if '--basecommand' in sys.argv:
-                kwargs['basecommand'] = sys.argv[sys.argv.index('--basecommand')+1]
+            arg2cwl_parser.add_argument('--generate_cwl_tool', action='store_true')
+            arg2cwl_args = arg2cwl_parser.parse_args(*args, **kwargs)
+            print(arg2cwl_args.tools)
+            shebang = re.search(r'\./\w*?.py$', arg2cwl_parser.prog)
+            commands = [arg2cwl_parser.prog.split('/')[-1]]
+            if arg2cwl_args.tools:
+                commands.extend(arg2cwl_args.tools)
+            command = ' '.join(commands)
+            kwargs['command'] = command.strip()
+            if arg2cwl_args.file:
+                kwargs['path'] = arg2cwl_args.file
+            if arg2cwl_args.basecommand:
+                kwargs['basecommand'] = arg2cwl_args.basecommand
             elif shebang:
                 kwargs['basecommand'] = shebang.group(0)
             self.parse_args_cwl(*args, **kwargs)
-        # TODO: reorganize to a separate CLI
         elif '--generate_galaxy_xml' in sys.argv:
             self.parse_args_galaxy_nouse(*args, **kwargs)
+        elif '--help_arg2cwl' in sys.argv:
+            arg2cwl_parser.print_help()
+            sys.exit()
+        # TODO: discuss standalone CLI, i.e. $ argparse2cwl <tool command> <options>
         else:
             return ap.ArgumentParser.parse_args(self, *args, **kwargs)
 

--- a/argparse/__init__.py
+++ b/argparse/__init__.py
@@ -67,13 +67,19 @@ tools = []
 
 def get_arg2cwl_parser():
     help_text = """
-    argparse2cwl forms CWL tool description from Python tool
+    argparse2cwl forms CWL command line tool from Python tool
     """
     arg2cwl_parser = ap.ArgumentParser(prog=sys.argv[0], description=help_text, add_help=False)
-    arg2cwl_parser.add_argument('tools', nargs='*', help='Your tool run commands without arguments')
-    arg2cwl_parser.add_argument('-f', '--file', help='Destination file for writing CWL tool definition')
-    arg2cwl_parser.add_argument('-b', '--basecommand', help='Command that appears in `basecommand` field in CWL tool definition')
-    arg2cwl_parser.add_argument('-ha', '--help_arg2cwl', help='show this help message and exit', action='help')
+    arg2cwl_parser.add_argument('tools', nargs='*',
+                                help='Command for running your tool(s), without arguments')
+    arg2cwl_parser.add_argument('-d', '--directory',
+                                help='Directory for placing formed CWL tool')
+    arg2cwl_parser.add_argument('-b', '--basecommand',
+                                help='Command that appears in `basecommand` field in CWL tool')
+    arg2cwl_parser.add_argument('-o', '--output_section',
+                                help='File with output section which will be appended to a formed CWL tool')
+    arg2cwl_parser.add_argument('-ha', '--help_arg2cwl',
+                                help='Show this help message and exit', action='help')
     return arg2cwl_parser
 
 
@@ -112,26 +118,33 @@ class ArgumentParser(ap.ArgumentParser):
         self.argument_list.append(result)
 
     def parse_args(self, *args, **kwargs):
+
         arg2cwl_parser = get_arg2cwl_parser()
+
         if '--generate_cwl_tool' in sys.argv:
             arg2cwl_parser.add_argument('--generate_cwl_tool', action='store_true')
             arg2cwl_args = arg2cwl_parser.parse_args(*args, **kwargs)
-            print(arg2cwl_args.tools)
-            shebang = re.search(r'\./\w*?.py$', arg2cwl_parser.prog)
+
             commands = [arg2cwl_parser.prog.split('/')[-1]]
             if arg2cwl_args.tools:
                 commands.extend(arg2cwl_args.tools)
             command = ' '.join(commands)
             kwargs['command'] = command.strip()
-            if arg2cwl_args.file:
-                kwargs['path'] = arg2cwl_args.file
-            if arg2cwl_args.basecommand:
-                kwargs['basecommand'] = arg2cwl_args.basecommand
-            elif shebang:
+
+            attrs = ['directory', 'output_section', 'basecommand']
+            for arg in attrs:
+                if getattr(arg2cwl_args, arg):
+                    kwargs[arg] = getattr(arg2cwl_args, arg)
+
+            shebang = re.search(r'\./\w*?.py$', arg2cwl_parser.prog)
+            if shebang:
                 kwargs['basecommand'] = shebang.group(0)
+
             self.parse_args_cwl(*args, **kwargs)
+
         elif '--generate_galaxy_xml' in sys.argv:
             self.parse_args_galaxy_nouse(*args, **kwargs)
+
         elif '--help_arg2cwl' in sys.argv:
             arg2cwl_parser.print_help()
             sys.exit()
@@ -150,7 +163,10 @@ class ArgumentParser(ap.ArgumentParser):
             else:
                 # build up wrappers if the user actually requests it, otherwise build all wrappers
                 if kwargs.get('command', argp.prog) in argp.prog:
-                    tool = cwlt.CWLTool(argp.prog, argp.description, kwargs.get('basecommand', ''))
+                    tool = cwlt.CWLTool(argp.prog,
+                                        argp.description,
+                                        kwargs.get('basecommand', ''),
+                                        kwargs.get('output_section', ''))
                     at = act.ArgparseCWLTranslation()
                     for result in argp._actions:
                         argument_type = result.__class__.__name__

--- a/argparse/__init__.py
+++ b/argparse/__init__.py
@@ -192,7 +192,7 @@ class ArgumentParser(ap.ArgumentParser):
                     print(data)
                 else:
                     continue
-        sys.exit()
+        sys.exit(0)
 
     def parse_args_galaxy_nouse(self, *args, **kwargs):
         self.tool = gxt.Tool(

--- a/argparse/argparse_cwl_translation.py
+++ b/argparse/argparse_cwl_translation.py
@@ -13,7 +13,7 @@ class ArgparseCWLTranslation(object):
     def __init__(self):
         self.positional_count = 0
 
-    def __cwl_param_from_type(self, param, position, default=None):
+    def __cwl_param_from_type(self, param, default=None):
         from argparse import FileType
         """Based on a type, convert to appropriate cwlt class
         """
@@ -30,6 +30,11 @@ class ArgparseCWLTranslation(object):
             prefix = param.option_strings[-1]
             if not param.required:
                 optional = True
+        if optional:
+            position = None
+        else:
+            self.positional_count += 1
+            position = self.positional_count
         kwargs_positional = {'id': param.dest,
                              'position': position,
                              'description': param.help,
@@ -81,9 +86,8 @@ class ArgparseCWLTranslation(object):
         param: argparse.Action
         """
         cwlparam = None
-        self.positional_count += 1
         param = self.__args_from_nargs(param)
-        cwlparam = self.__cwl_param_from_type(param, self.positional_count, default=param.default)
+        cwlparam = self.__cwl_param_from_type(param, default=param.default)
         return cwlparam
 
 
@@ -95,18 +99,16 @@ class ArgparseCWLTranslation(object):
 
     def _AppendAction(self, param, **kwargs):
         cwlparam = None
-        self.positional_count += 1
         param.items_type = param.type
         param.type = list
-        cwlparam = self.__cwl_param_from_type(param, self.positional_count, default=param.default)
+        cwlparam = self.__cwl_param_from_type(param, default=param.default)
         cwlparam.items_type = param.items_type
         return cwlparam
 
 
     def _StoreConstAction(self, param):
-        self.positional_count += 1
         param.type = bool
         param.default = 'null'
-        cwlparam = self.__cwl_param_from_type(param, self.positional_count, param.default)
+        cwlparam = self.__cwl_param_from_type(param, param.default)
         return cwlparam
 

--- a/argparse/argparse_cwl_translation.py
+++ b/argparse/argparse_cwl_translation.py
@@ -88,13 +88,9 @@ class ArgparseCWLTranslation(object):
 
 
     def _StoreTrueAction(self, param):
-        param.type = bool
-        param.default = True
         return self._StoreConstAction(param)
 
     def _StoreFalseAction(self, param):
-        param.type = bool
-        param.default = False
         return self._StoreConstAction(param)
 
     def _AppendAction(self, param, **kwargs):
@@ -109,6 +105,8 @@ class ArgparseCWLTranslation(object):
 
     def _StoreConstAction(self, param):
         self.positional_count += 1
+        param.type = bool
+        param.default = 'null'
         cwlparam = self.__cwl_param_from_type(param, self.positional_count, param.default)
         return cwlparam
 

--- a/argparse/templates/cwltool.j2
+++ b/argparse/templates/cwltool.j2
@@ -12,9 +12,6 @@ description: |
   {{ tool.description }}
 
 inputs:
-  {% block cwltool_inputs %}{% endblock %}
+  {{ inputs }}
 
-outputs:
-  {% block cwltool_outputs %}
-    []
-  {% endblock %}
+{{ outputs }}

--- a/argparse/templates/cwltool_inputs.j2
+++ b/argparse/templates/cwltool_inputs.j2
@@ -31,8 +31,10 @@
   default: {{ param.default }}
   {% endif %}
   {% if param.description %}  description: {{ param.description }}{% endif %}
+  {% if param.position or param.prefix %}
 
   inputBinding:
-    position: {{ param.position }}
+{% if param.position %}    position: {{ param.position }}{% endif %}
 {% if param.prefix %}    prefix: {{ param.prefix }} {% endif %}
+    {% endif %}
 {% endfor %}

--- a/argparse/templates/cwltool_inputs.j2
+++ b/argparse/templates/cwltool_inputs.j2
@@ -1,6 +1,3 @@
-{% extends "cwltool.j2" %}
-
-{% block cwltool_inputs %}
 {% if 'python' in basecommand %}
 
 - id: {{ tool.name }}
@@ -39,18 +36,3 @@
     position: {{ param.position }}
 {% if param.prefix %}    prefix: {{ param.prefix }} {% endif %}
 {% endfor %}
-{% endblock cwltool_inputs %}
-
-{% block cwltool_outputs %}
-{% for param in tool.outputs %}
-- id: {{ param.id + '_out'}}
-  type: File
-  {% if param.default %}default: {{ param.default }} {% endif %}
-  {% if param.description %}  description: {{ param.description }}{% endif %}
-
-  outputBinding:
-    glob: $(inputs.{{ param.id }}.path)
-{% else %}
-    []
-{% endfor %}
-{% endblock cwltool_outputs %}

--- a/argparse/templates/cwltool_outputs.j2
+++ b/argparse/templates/cwltool_outputs.j2
@@ -1,0 +1,12 @@
+outputs:
+{% for param in tool.outputs %}
+- id: {{ param.id + '_out'}}
+  type: File
+  {% if param.default %}default: {{ param.default }} {% endif %}
+  {% if param.description %}  description: {{ param.description }}{% endif %}
+
+  outputBinding:
+    glob: $(inputs.{{ param.id }}.path)
+{% else %}
+    []
+{% endfor %}

--- a/example.py
+++ b/example.py
@@ -1,3 +1,4 @@
+import io
 import argparse
 
 parser = argparse.ArgumentParser(description='Process some integers.', prefix_chars='-+', epilog="here's some epilog text", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -11,7 +12,7 @@ parser.add_argument('--sum', '-s', dest='accumulate', action='store_const',
         const=sum, default=max, help='sum the integers (default: find the max)')
 
 parser.add_argument('--foo', nargs='?', help='foo help')
-parser.add_argument('--file', nargs='?', help='foo help', type=file)
+parser.add_argument('--file', nargs='?', help='foo help', type=io.IOBase)
 parser.add_argument('--bar', nargs='*', default=[1, 2, 3], help='BAR!')
 #parser.add_argument('+f', action='store_const', const='43')
 parser.add_argument('--true', action='store_true', help='Store a true')

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(name="gxargparse",
         entry_points={
             'console_scripts': [
                     'gxargparse_check_path = gxargparse.check_path:main',
+                    # 'arg2cwl = gxargparse.arg2cwl:main'
                 ]
             },
         classifiers=[

--- a/test/test_arg2cwl.py
+++ b/test/test_arg2cwl.py
@@ -1,0 +1,44 @@
+import sys
+import unittest
+from unittest import mock
+import argparse
+
+
+class GeneralTestCase(unittest.TestCase):
+
+    def prepare_argument_parser(self):
+        parser = argparse.ArgumentParser(prog='test', description='test program')
+        parser.add_argument('keyword', metavar='Q', type=str, nargs=1,
+                            help='action keyword')
+
+        parser.add_argument('integers', metavar='N', type=int, nargs='+',
+                            help='an integer for the accumulator')
+
+        parser.add_argument('--sum', '-s', dest='accumulate', action='store_const',
+                            const=sum, default=max, help='sum the integers (default: find the max)')
+
+        parser.add_argument('--foo', nargs='?', help='foo help')
+        parser.add_argument('--file', nargs='?', help='foo help', type=argparse.FileType('w'))
+        parser.add_argument('--bar', nargs='*', default=[1, 2, 3], help='BAR!')
+        parser.add_argument('--true', action='store_true', help='Store a true')
+        parser.add_argument('--false', action='store_false', help='Store a false')
+        parser.add_argument('--append', action='append', help='Append a value')
+
+        parser.add_argument('--nargs2', nargs=2, help='nargs2')
+
+        parser.add_argument('--mode', choices=['rock', 'paper', 'scissors'], default='scissors')
+
+        parser.add_argument('--version', action='version', version='2.0')
+        return parser
+
+    def test_general(self):
+        parser = self.prepare_argument_parser()
+        testargs = ["python3", "test.py", "--generate_cwl_tool"]
+        print(sys.version)
+        with self.assertRaises(SystemExit) as result:
+            with unittest.mock.patch.object(sys, 'argv', testargs):
+                parser.parse_args()
+        self.assertEqual(result.exception.code, 0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- changed the structure of templates so that they can be divided into smaller parts
- rewrote interface to `argparse2cwl`, now a user can get information about `a2c` arguments with passing `-ha` or `--help_arg2cwl` option to any tool he/she wants to wrap.
- added an option of plugging hand-written output section to CWL tool
- removed `posititon` field for optional arguments
- simple general test
