### PR TITLE
Mapping ids in CWL v.1.0

### DIFF
--- a/argparse/__init__.py
+++ b/argparse/__init__.py
@@ -82,6 +82,8 @@ def get_arg2cwl_parser():
                                 help='File with output section which will be put to a formed CWL tool')
     arg2cwl_parser.add_argument('-go', '--generate_outputs', action='store_true',
                                 help='Form output section from args than contain `output` keyword in their names')
+    arg2cwl_parser.add_argument('--map_ids', action='store_true',
+                                help='Map identifier to the corresponding CommandInputParameter')
     arg2cwl_parser.add_argument('--help_arg2cwl',
                                 help='Show this help message and exit', action='help')
     return arg2cwl_parser
@@ -153,7 +155,7 @@ class ArgumentParser(ap.ArgumentParser):
             else:
                 formcommand += kwargs['command']
 
-            attrs = ['directory', 'output_section', 'basecommand', 'generate_outputs']
+            attrs = ['directory', 'output_section', 'basecommand', 'generate_outputs', 'map_ids']
             for arg in attrs:
                 if getattr(arg2cwl_args, arg):
                     kwargs[arg] = getattr(arg2cwl_args, arg)
@@ -164,6 +166,8 @@ class ArgumentParser(ap.ArgumentParser):
                 formcommand += ' -b {0}'.format(kwargs['basecommand'])
             if kwargs.get('generate_outputs', ''):
                 formcommand += ' -go'
+            if kwargs.get('map_ids', ''):
+                formcommand += ' --map_ids'
             kwargs['formcommand'] = formcommand
 
             self.parse_args_cwl(*args, **kwargs)
@@ -197,7 +201,8 @@ class ArgumentParser(ap.ArgumentParser):
                                         argp.description,
                                         kwargs['formcommand'],
                                         kwargs.get('basecommand', ''),
-                                        kwargs.get('output_section', ''))
+                                        kwargs.get('output_section', ''),
+                                        kwargs.get('map_ids', ''))
                     at = act.ArgparseCWLTranslation(kwargs.get('generate_outputs', False))
                     for result in argp._actions:
                         argument_type = result.__class__.__name__

--- a/argparse/__init__.py
+++ b/argparse/__init__.py
@@ -8,7 +8,7 @@ import re
 
 from argparse.cwl_tool import CWLTool
 
-__version__ = '0.2.5'
+__version__ = '0.2.7'
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -56,12 +56,7 @@ from . import cwl_tool as cwlt
 # This fetches a reference to ourselves
 __selfmodule__ = sys.modules[load_conflicting_package.__module__]
 # Static list of imports
-__argparse_exports__ = ['HelpFormatter', 'RawDescriptionHelpFormatter',
-                        'ArgumentDefaultsHelpFormatter', 'FileType',
-                        'SUPPRESS', 'OPTIONAL', 'ZERO_OR_MORE', 'ONE_OR_MORE',
-                        'PARSER', 'REMAINDER', '_UNRECOGNIZED_ARGS_ATTR',
-                        '_VersionAction', '_SubParsersAction', 'Action']
-
+__argparse_exports__ = list(filter(lambda x: not x.startswith('__'), dir(ap)))
 # Set the attribute on ourselves.
 for x in __argparse_exports__:
     setattr(__selfmodule__, x, getattr(ap, x))

--- a/argparse/__init__.py
+++ b/argparse/__init__.py
@@ -82,8 +82,8 @@ def get_arg2cwl_parser():
                                 help='File with output section which will be put to a formed CWL tool')
     arg2cwl_parser.add_argument('-go', '--generate_outputs', action='store_true',
                                 help='Form output section from args than contain `output` keyword in their names')
-    arg2cwl_parser.add_argument('--map_ids', action='store_true',
-                                help='Map identifier to the corresponding CommandInputParameter')
+    arg2cwl_parser.add_argument('--no_map', action='store_true',
+                                help='Do not map identifier to the corresponding CommandInputParameter')
     arg2cwl_parser.add_argument('--help_arg2cwl',
                                 help='Show this help message and exit', action='help')
     return arg2cwl_parser
@@ -155,7 +155,7 @@ class ArgumentParser(ap.ArgumentParser):
             else:
                 formcommand += kwargs['command']
 
-            attrs = ['directory', 'output_section', 'basecommand', 'generate_outputs', 'map_ids']
+            attrs = ['directory', 'output_section', 'basecommand', 'generate_outputs', 'no_map']
             for arg in attrs:
                 if getattr(arg2cwl_args, arg):
                     kwargs[arg] = getattr(arg2cwl_args, arg)
@@ -166,8 +166,8 @@ class ArgumentParser(ap.ArgumentParser):
                 formcommand += ' -b {0}'.format(kwargs['basecommand'])
             if kwargs.get('generate_outputs', ''):
                 formcommand += ' -go'
-            if kwargs.get('map_ids', ''):
-                formcommand += ' --map_ids'
+            if kwargs.get('no_map', ''):
+                formcommand += ' --no_map'
             kwargs['formcommand'] = formcommand
 
             self.parse_args_cwl(*args, **kwargs)
@@ -202,7 +202,7 @@ class ArgumentParser(ap.ArgumentParser):
                                         kwargs['formcommand'],
                                         kwargs.get('basecommand', ''),
                                         kwargs.get('output_section', ''),
-                                        kwargs.get('map_ids', ''))
+                                        not kwargs.get('no_map', ''))
                     at = act.ArgparseCWLTranslation(kwargs.get('generate_outputs', False))
                     for result in argp._actions:
                         argument_type = result.__class__.__name__

--- a/argparse/__init__.py
+++ b/argparse/__init__.py
@@ -82,8 +82,6 @@ def get_arg2cwl_parser():
                                 help='File with output section which will be put to a formed CWL tool')
     arg2cwl_parser.add_argument('-go', '--generate_outputs', action='store_true',
                                 help='Form output section from args than contain `output` keyword in their names')
-    arg2cwl_parser.add_argument('--no_map', action='store_true',
-                                help='Do not map identifier to the corresponding CommandInputParameter')
     arg2cwl_parser.add_argument('--help_arg2cwl',
                                 help='Show this help message and exit', action='help')
     return arg2cwl_parser
@@ -155,7 +153,7 @@ class ArgumentParser(ap.ArgumentParser):
             else:
                 formcommand += kwargs['command']
 
-            attrs = ['directory', 'output_section', 'basecommand', 'generate_outputs', 'no_map']
+            attrs = ['directory', 'output_section', 'basecommand', 'generate_outputs']
             for arg in attrs:
                 if getattr(arg2cwl_args, arg):
                     kwargs[arg] = getattr(arg2cwl_args, arg)
@@ -166,8 +164,6 @@ class ArgumentParser(ap.ArgumentParser):
                 formcommand += ' -b {0}'.format(kwargs['basecommand'])
             if kwargs.get('generate_outputs', ''):
                 formcommand += ' -go'
-            if kwargs.get('no_map', ''):
-                formcommand += ' --no_map'
             kwargs['formcommand'] = formcommand
 
             self.parse_args_cwl(*args, **kwargs)
@@ -201,8 +197,7 @@ class ArgumentParser(ap.ArgumentParser):
                                         argp.description,
                                         kwargs['formcommand'],
                                         kwargs.get('basecommand', ''),
-                                        kwargs.get('output_section', ''),
-                                        not kwargs.get('no_map', ''))
+                                        kwargs.get('output_section', ''))
                     at = act.ArgparseCWLTranslation(kwargs.get('generate_outputs', False))
                     for result in argp._actions:
                         argument_type = result.__class__.__name__

--- a/argparse/argparse_galaxy_translation.py
+++ b/argparse/argparse_galaxy_translation.py
@@ -1,4 +1,3 @@
-from builtins import object
 import galaxyxml.tool.parameters as gxtp
 
 class ArgparseGalaxyTranslation(object):

--- a/argparse/cwl_tool.py
+++ b/argparse/cwl_tool.py
@@ -66,7 +66,7 @@ class FileParam(InputParam):
 
 class CWLTool(object):
 
-    def __init__(self, name, description, formcommand, basecommand=None, output_file=None, map_ids=True):
+    def __init__(self, name, description, formcommand, basecommand=None, output_file=None):
         self.name = name
         self.output_file = output_file  # file with manually filled output section
         if description:
@@ -82,7 +82,6 @@ class CWLTool(object):
         else:
             self.basecommands = self.name.split()
         self.formcommand = formcommand
-        self.map_ids = map_ids
         self.inputs = []
         self.outputs = []
 
@@ -90,12 +89,12 @@ class CWLTool(object):
         inputs_template = self.env.get_template('cwltool_inputs.j2')
         outputs_template = self.env.get_template('cwltool_outputs.j2')
         main_template = self.env.get_template('cwltool.j2')
-        inputs = inputs_template.render(tool=self, basecommand=self.basecommands, map_ids=self.map_ids)
+        inputs = inputs_template.render(tool=self, basecommand=self.basecommands)
         if self.output_file:
             with open(self.output_file) as f:
                 outputs = f.read()
         else:
-            outputs = outputs_template.render(tool=self, map_ids=self.map_ids)
+            outputs = outputs_template.render(tool=self)
         import argparse
         return main_template.render(tool=self,
                                     version=argparse.__version__,

--- a/argparse/cwl_tool.py
+++ b/argparse/cwl_tool.py
@@ -1,11 +1,10 @@
 import re
-from builtins import object
 import os
 
 from jinja2 import Environment, FileSystemLoader
 
 
-class Param(object):
+class Param:
     def __init__(self, id, position=None, description=None, default=None, prefix=None, optional=False, items_type=None):
         self.id = id
         self.position = position

--- a/argparse/cwl_tool.py
+++ b/argparse/cwl_tool.py
@@ -66,7 +66,7 @@ class FileParam(InputParam):
 
 class CWLTool(object):
 
-    def __init__(self, name, description, formcommand, basecommand=None, output_file=None, map_ids=False):
+    def __init__(self, name, description, formcommand, basecommand=None, output_file=None, map_ids=True):
         self.name = name
         self.output_file = output_file  # file with manually filled output section
         if description:

--- a/argparse/cwl_tool.py
+++ b/argparse/cwl_tool.py
@@ -66,7 +66,7 @@ class FileParam(InputParam):
 
 class CWLTool(object):
 
-    def __init__(self, name, description, formcommand, basecommand=None, output_file=None):
+    def __init__(self, name, description, formcommand, basecommand=None, output_file=None, map_ids=False):
         self.name = name
         self.output_file = output_file  # file with manually filled output section
         if description:
@@ -82,6 +82,7 @@ class CWLTool(object):
         else:
             self.basecommands = self.name.split()
         self.formcommand = formcommand
+        self.map_ids = map_ids
         self.inputs = []
         self.outputs = []
 
@@ -89,12 +90,12 @@ class CWLTool(object):
         inputs_template = self.env.get_template('cwltool_inputs.j2')
         outputs_template = self.env.get_template('cwltool_outputs.j2')
         main_template = self.env.get_template('cwltool.j2')
-        inputs = inputs_template.render(tool=self, basecommand=self.basecommands)
+        inputs = inputs_template.render(tool=self, basecommand=self.basecommands, map_ids=self.map_ids)
         if self.output_file:
             with open(self.output_file) as f:
                 outputs = f.read()
         else:
-            outputs = outputs_template.render(tool=self)
+            outputs = outputs_template.render(tool=self, map_ids=self.map_ids)
         import argparse
         return main_template.render(tool=self,
                                     version=argparse.__version__,

--- a/argparse/templates/cwltool.j2
+++ b/argparse/templates/cwltool.j2
@@ -3,7 +3,7 @@
 # To generate again: $ {{ formcommand }} --generate_cwl_tool
 # Help: $ {{ stripped_options_command }} --help_arg2cwl
 
-cwlVersion: "cwl:draft-3"
+cwlVersion: "cwl:v1.0"
 
 class: CommandLineTool
 baseCommand: {{ basecommand }}

--- a/argparse/templates/cwltool_inputs.j2
+++ b/argparse/templates/cwltool_inputs.j2
@@ -1,23 +1,13 @@
 {% if 'python' in basecommand[0] %}
-{% set program_param %}
-  type: File
-  default:
-    class: File
-    path: {{ tool.name }}
-  inputBinding:
-    position: 0
-{% endset %}
-{% if map_ids %}
 {{ tool.name }}:
-  {{ program_param|indent(2) }}
-{% else %}
-
-- id: {{ tool.name }}
-{{ program_param }}
-{% endif %}
+    type: File
+    default:
+      class: File
+      path: {{ tool.name }}
+    inputBinding:
+      position: 0
 {% endif %}
 {% for param in tool.inputs %}
-
 {% set param_attrs %}
 {% if param.type == "enum" or param.type == "array"%}
   type:
@@ -46,12 +36,7 @@
     {% endif %}
     {% endset %}
 
-{% if map_ids %}
   {{ param.id }}:
   {{ param_attrs|indent(2) }}
-    {% else %}
-- id: {{ param.id }}
-{{ param_attrs }}
-{% endif %}
 {% endfor %}
 

--- a/argparse/templates/cwltool_inputs.j2
+++ b/argparse/templates/cwltool_inputs.j2
@@ -1,18 +1,25 @@
 {% if 'python' in basecommand[0] %}
-
-- id: {{ tool.name }}
+{% set program_param %}
   type: File
   default:
     class: File
     path: {{ tool.name }}
   inputBinding:
     position: 0
+{% endset %}
+{% if map_ids %}
+{{ tool.name }}:
+  {{ program_param|indent(2) }}
+{% else %}
+
+- id: {{ tool.name }}
+{{ program_param }}
+{% endif %}
 {% endif %}
 {% for param in tool.inputs %}
 
-
-- id: {{ param.id }}
-  {% if param.type == "enum" or param.type == "array"%}
+{% set param_attrs %}
+{% if param.type == "enum" or param.type == "array"%}
   type:
     {% if param.optional %}  - "null"
   - type: {{ param.type }}{% else %}
@@ -37,4 +44,14 @@
 {% if param.position %}    position: {{ param.position }}{% endif %}
 {% if param.prefix %}    prefix: {{ param.prefix }} {% endif %}
     {% endif %}
+    {% endset %}
+
+{% if map_ids %}
+  {{ param.id }}:
+  {{ param_attrs|indent(2) }}
+    {% else %}
+- id: {{ param.id }}
+{{ param_attrs }}
+{% endif %}
 {% endfor %}
+

--- a/argparse/templates/cwltool_outputs.j2
+++ b/argparse/templates/cwltool_outputs.j2
@@ -9,13 +9,8 @@ outputs:
   outputBinding:
     glob: $(inputs.{{ param.id }}.path)
 {% endset %}
-{% if map_ids %}
   {{ param.id + '_out'}}:
   {{ param_attrs|indent(2) }}
-{% else %}
-- id: {{ param.id + '_out'}}
-{{ param_attrs }}
-{% endif %}
 {% else %}
     []
 {% endfor %}

--- a/argparse/templates/cwltool_outputs.j2
+++ b/argparse/templates/cwltool_outputs.j2
@@ -1,14 +1,21 @@
 outputs:
 {% for param in tool.outputs %}
 
-- id: {{ param.id + '_out'}}
+{% set param_attrs %}
   type: File
   {% if param.default %}  default: {{ param.default }} {% endif %}
-
 {% if param.description %}  description: {{ param.description }}{% endif %}
 
   outputBinding:
     glob: $(inputs.{{ param.id }}.path)
+{% endset %}
+{% if map_ids %}
+  {{ param.id + '_out'}}:
+  {{ param_attrs|indent(2) }}
+{% else %}
+- id: {{ param.id + '_out'}}
+  {{ param_attrs }}
+{% endif %}
 {% else %}
     []
 {% endfor %}

--- a/argparse/templates/cwltool_outputs.j2
+++ b/argparse/templates/cwltool_outputs.j2
@@ -14,7 +14,7 @@ outputs:
   {{ param_attrs|indent(2) }}
 {% else %}
 - id: {{ param.id + '_out'}}
-  {{ param_attrs }}
+{{ param_attrs }}
 {% endif %}
 {% else %}
     []

--- a/argparse/templates/cwltool_outputs.j2
+++ b/argparse/templates/cwltool_outputs.j2
@@ -4,6 +4,7 @@ outputs:
 {% set param_attrs %}
   type: File
   {% if param.default %}  default: {{ param.default }} {% endif %}
+
 {% if param.description %}  description: {{ param.description }}{% endif %}
 
   outputBinding:

--- a/example.py
+++ b/example.py
@@ -1,3 +1,4 @@
+# /usr/bin/python3
 import io
 import argparse
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 galaxyxml
+jinja2>=2.8
+future

--- a/test/cwl_classes.py
+++ b/test/cwl_classes.py
@@ -51,14 +51,26 @@ class Tool:
             raise ValueError('Wrong tool class')
         self.basecommand = tool['baseCommand']
         self.inputs = OrderedDict()
-        for param_dict in tool['inputs']:
-            param = InputParam(param_dict)
-            self.inputs[param.id] = param
+        if type(tool['inputs']) is list:  # ids not mapped
+            for param_dict in tool['inputs']:
+                param = InputParam(param_dict)
+                self.inputs[param.id] = param
+        elif type(tool['inputs']) is dict:  # ids mapped
+            for id, param_dict in tool['inputs'].items():
+                param_dict['id'] = id
+                param = InputParam(param_dict)
+                self.inputs[id] = param
         self.outputs = OrderedDict()
         if tool['outputs']:
-            for param in tool['outputs']:
-                param = OutputParam(param)
-                self.outputs[param.id] = param
+            if type(tool['outputs']) is list:  # ids not mapped
+                for param_dict in tool['outputs']:
+                    param = OutputParam(param_dict)
+                    self.outputs[param.id] = param
+            elif type(tool['outputs']) is dict:  # ids mapped
+                for id, param_dict in tool['outputs'].items():
+                    param_dict['id'] = id
+                    param = OutputParam(param_dict)
+                    self.outputs[id] = param
         self.description = tool.get('description', '')
         self.cwl_version = tool.get('cwlVersion', '')
 

--- a/test/test_arg2cwl.py
+++ b/test/test_arg2cwl.py
@@ -84,7 +84,6 @@ class GeneralTestCase(unittest.TestCase):
                 parser.parse_args()
         self.assertEqual(result.exception.code, 0)
 
-
     def test_output_directory_storage_for_CWL_tool(self):
         parser = self.prepare_argument_parser(name="test-directory.py")
         directory = os.path.dirname(__file__)
@@ -193,7 +192,6 @@ class CWLTestCase(unittest.TestCase):
                 else:
                     self.assertEqual(action_type, arg_type)
 
-
     def test_output_replacement(self):
         """
         `--output_section FILENAME` option
@@ -249,13 +247,11 @@ class CWLTestCase(unittest.TestCase):
         for arg in arguments:
             self.assertIn(arg, tool.inputs.keys())
 
-
-
     def test_prefixes(self):
         parser_name = 'test-prefix-chars.py'
         parser = argparse.ArgumentParser(prog=parser_name,
                                          prefix_chars='-+',
-                                         description='test prefix chars progrma')
+                                         description='test prefix chars program')
         parser.add_argument('keyword', type=str, nargs=1,
                             help='action keyword')
         parser.add_argument('integers', metavar='N', type=int, nargs='+',
@@ -277,6 +273,11 @@ class CWLTestCase(unittest.TestCase):
         tool = Tool(self.test_dir + parser_name.replace('.py', '.cwl').strip('./'))
         for optional in self._strip_help_version_actions(parser._optionals._group_actions):
             self.assertEqual(tool.inputs[optional.dest].input_binding.prefix, optional.option_strings[0])
+
+    def test_map_ids(self):
+        parser_name = 'test_map_ids.py'
+        testargs = [parser_name, "--generate_cwl_tool", "-d", self.test_dir, "-b", "python", "--no_map"]
+        parser, tool = self.get_simple_tool(parser_name, testargs)
 
 
 if __name__ == '__main__':

--- a/test/test_arg2cwl.py
+++ b/test/test_arg2cwl.py
@@ -274,11 +274,6 @@ class CWLTestCase(unittest.TestCase):
         for optional in self._strip_help_version_actions(parser._optionals._group_actions):
             self.assertEqual(tool.inputs[optional.dest].input_binding.prefix, optional.option_strings[0])
 
-    def test_map_ids(self):
-        parser_name = 'test_map_ids.py'
-        testargs = [parser_name, "--generate_cwl_tool", "-d", self.test_dir, "-b", "python", "--no_map"]
-        parser, tool = self.get_simple_tool(parser_name, testargs)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -58,7 +58,7 @@ class GeneralTests(TestCase):
         ]
 
         results = list(self.dict_product(a, 'b', [None, 1]))
-        self.assertItemsEqual(correct, results)
+        self.assertCountEqual(correct, results)
 
     def __blacklist(self, item_list):
         for i in item_list:
@@ -102,6 +102,5 @@ class GeneralTests(TestCase):
         return parser.parse_args(args)
 
 
-    def test_add_argument(self):
-        parser = self.parse_args(['-a', ])
-
+class SimpleTests(TestCase):
+    pass


### PR DESCRIPTION
Added an ability to generate tools with a new CWL syntax denoted by the map<> syntax. Example: inputs contains a list of items, each with an id. Now one can specify a mapping of that identifier by passing `--map_ids` option along with `--generate_cwl_tool`.
So, 

```
inputs:
 - id: one
   type: string
   doc: First input parameter
 - id: two
   type: int
   doc: Second input parameter
```

will become

```
inputs:
 one:
  type: string
  doc: First input parameter
 two:
  type: int
  doc: Second input parameter

```
